### PR TITLE
feat: add streaming support for chatbot and task agents

### DIFF
--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -86,6 +86,84 @@ const directChat = await client.chatWithAgentDirect(
 console.log('Direct chat response:', directChat.data.response);
 ```
 
+### Streaming Chat (Real-time Response)
+
+For real-time streaming responses, use the streaming methods:
+
+```javascript
+// Streaming with session token (recommended)
+const session = await client.createAgentSession('agent_789');
+
+await client.chatWithAgentStream(
+  session.session_token,
+  'Tell me a long story',
+  null, // conversationId
+  'user-123', // userIdentifier
+  {}, // dynamicContext
+  (chunk) => {
+    // Called for each piece of the response as it streams in
+    process.stdout.write(chunk);
+  },
+  (data) => {
+    // Called when the response is complete
+    console.log('\n✅ Chat completed!');
+    console.log('Session info:', data.session_info);
+  },
+  (error) => {
+    // Called if there's an error
+    console.error('❌ Streaming error:', error.message);
+  }
+);
+
+// Direct streaming with API key
+await client.chatWithAgentDirectStream(
+  'org_123',
+  'proj_456',
+  'agent_789',
+  'Stream me a response!',
+  null, // conversationId
+  'user-123', // userIdentifier
+  {}, // dynamicContext
+  (chunk) => process.stdout.write(chunk), // onChunk
+  (data) => console.log('\n✅ Complete!'), // onComplete
+  (error) => console.error('❌ Error:', error) // onError
+);
+```
+
+### Task Agent Execution
+
+```javascript
+// Regular task execution
+const taskResult = await client.executeTaskAgent(
+  session.session_token,
+  'Analyze this data: [1,2,3,4,5]'
+);
+
+console.log('Task output:', taskResult.data.output);
+
+// Streaming task execution
+await client.executeTaskAgentStream(
+  session.session_token,
+  'Process this large dataset...',
+  {}, // context
+  (chunk) => process.stdout.write(chunk), // onChunk
+  (data) => console.log('\n✅ Task completed!'), // onComplete
+  (error) => console.error('❌ Task error:', error) // onError
+);
+
+// Direct task execution with streaming
+await client.executeTaskAgentDirectStream(
+  'org_123',
+  'proj_456',
+  'agent_789',
+  'Complex analysis task',
+  {}, // context
+  (chunk) => process.stdout.write(chunk), // onChunk
+  (data) => console.log('\n✅ Analysis complete!'), // onComplete
+  (error) => console.error('❌ Analysis error:', error) // onError
+);
+```
+
 ### Get Information
 
 ```javascript

--- a/packages/js-sdk/dist/index.js
+++ b/packages/js-sdk/dist/index.js
@@ -28,6 +28,28 @@
  * 
  * console.log(chatResult.response); // Agent's text response
  * console.log(chatResult.suggestions); // Suggested follow-up questions
+ *
+ * // Streaming chat with session token
+ * await client.chatWithAgentStream(
+ *   session.session_token,
+ *   'Tell me a story',
+ *   null, // conversationId
+ *   null, // userIdentifier
+ *   {}, // dynamicContext
+ *   (chunk) => process.stdout.write(chunk), // onChunk
+ *   (data) => console.log('\n✓ Complete:', data), // onComplete
+ *   (error) => console.error('❌ Error:', error) // onError
+ * );
+ *
+ * // Streaming task execution
+ * await client.executeTaskAgentStream(
+ *   session.session_token,
+ *   'Analyze this data: [1,2,3,4,5]',
+ *   {}, // context
+ *   (chunk) => process.stdout.write(chunk), // onChunk
+ *   (data) => console.log('\n✓ Task Complete:', data), // onComplete
+ *   (error) => console.error('❌ Error:', error) // onError
+ * );
  * ```
  */
 
@@ -139,6 +161,82 @@ class LLMCrafterClient {
     }
 
     throw lastError;
+  }
+
+  /**
+   * Make a streaming request to the API
+   * @private
+   */
+  async _streamRequest(endpoint, options = {}, onChunk, onComplete, onError) {
+    const url = `${this.baseUrl}${endpoint}`;
+    const config = {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`,
+        ...options.headers,
+      },
+      ...options,
+    };
+
+    if (options.body) {
+      config.body = JSON.stringify(options.body);
+    }
+
+    try {
+      const response = await fetch(url, config);
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        const error = new Error(errorData.error || `HTTP ${response.status}`);
+        error.status = response.status;
+        error.code = errorData.code;
+        error.response = errorData;
+        onError(error);
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+
+          if (done) {
+            break;
+          }
+
+          const chunk = decoder.decode(value, { stream: true });
+          const lines = chunk.split('\n');
+
+          for (const line of lines) {
+            if (line.startsWith('data: ')) {
+              try {
+                const data = JSON.parse(line.slice(6));
+                
+                if (data.type === 'response_chunk') {
+                  onChunk(data.content);
+                } else if (data.type === 'complete') {
+                  onComplete(data);
+                } else if (data.type === 'error') {
+                  const error = new Error(data.error || 'Streaming error');
+                  error.code = data.code;
+                  onError(error);
+                }
+              } catch (parseError) {
+                // Ignore malformed JSON lines
+                console.warn('Failed to parse SSE data:', line);
+              }
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    } catch (error) {
+      onError(error);
+    }
   }
 
   // ===== PROMPT EXECUTION =====
@@ -273,6 +371,72 @@ class LLMCrafterClient {
   }
 
   /**
+   * Chat with an agent using streaming (session token)
+   * @param {string} sessionToken - Session token from createAgentSession
+   * @param {string} message - Message to send to the agent
+   * @param {string} conversationId - Optional conversation ID
+   * @param {string} userIdentifier - Optional user identifier
+   * @param {Object} dynamicContext - Optional dynamic context
+   * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+   * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+   * @param {Function} onError - Callback function for errors: (error: Error) => void
+   * @returns {Promise<void>} Promise that resolves when streaming starts
+   */
+  async chatWithAgentStream(
+    sessionToken,
+    message,
+    conversationId = null,
+    userIdentifier = null,
+    dynamicContext = {},
+    onChunk = () => {},
+    onComplete = () => {},
+    onError = () => {}
+  ) {
+    return this._streamRequest('/external/agents/chat/stream', {
+      method: 'POST',
+      headers: {
+        'X-Session-Token': sessionToken,
+      },
+      body: {
+        message,
+        conversationId,
+        userIdentifier,
+        dynamicContext,
+      },
+    }, onChunk, onComplete, onError);
+  }
+
+  /**
+   * Execute a task agent using streaming (session token)
+   * @param {string} sessionToken - Session token from createAgentSession
+   * @param {string} input - Input for the task agent
+   * @param {Object} context - Optional context
+   * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+   * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+   * @param {Function} onError - Callback function for errors: (error: Error) => void
+   * @returns {Promise<void>} Promise that resolves when streaming starts
+   */
+  async executeTaskAgentStream(
+    sessionToken,
+    input,
+    context = {},
+    onChunk = () => {},
+    onComplete = () => {},
+    onError = () => {}
+  ) {
+    return this._streamRequest('/external/agents/execute/stream', {
+      method: 'POST',
+      headers: {
+        'X-Session-Token': sessionToken,
+      },
+      body: {
+        input,
+        context,
+      },
+    }, onChunk, onComplete, onError);
+  }
+
+  /**
    * Chat with an agent using API key (simpler but less secure)
    * @param {string} orgId - Organization ID
    * @param {string} projectId - Project ID
@@ -303,6 +467,86 @@ class LLMCrafterClient {
           dynamicContext,
         },
       }
+    );
+  }
+
+  /**
+   * Chat with an agent using streaming (API key-based)
+   * @param {string} orgId - Organization ID
+   * @param {string} projectId - Project ID 
+   * @param {string} agentId - Agent ID
+   * @param {string} message - Message to send to the agent
+   * @param {string} conversationId - Optional conversation ID
+   * @param {string} userIdentifier - Optional user identifier
+   * @param {Object} dynamicContext - Optional dynamic context
+   * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+   * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+   * @param {Function} onError - Callback function for errors: (error: Error) => void
+   * @returns {Promise<void>} Promise that resolves when streaming starts
+   */
+  async chatWithAgentDirectStream(
+    orgId,
+    projectId,
+    agentId,
+    message,
+    conversationId = null,
+    userIdentifier = null,
+    dynamicContext = {},
+    onChunk = () => {},
+    onComplete = () => {},
+    onError = () => {}
+  ) {
+    return this._streamRequest(
+      `/organizations/${orgId}/projects/${projectId}/agents/${agentId}/chat/stream`,
+      {
+        method: 'POST',
+        body: {
+          message,
+          conversationId,
+          userIdentifier,
+          dynamicContext,
+        },
+      },
+      onChunk,
+      onComplete,
+      onError
+    );
+  }
+
+  /**
+   * Execute a task agent using streaming (API key-based)
+   * @param {string} orgId - Organization ID
+   * @param {string} projectId - Project ID
+   * @param {string} agentId - Agent ID
+   * @param {string} input - Input for the task agent
+   * @param {Object} context - Optional context
+   * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+   * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+   * @param {Function} onError - Callback function for errors: (error: Error) => void
+   * @returns {Promise<void>} Promise that resolves when streaming starts
+   */
+  async executeTaskAgentDirectStream(
+    orgId,
+    projectId,
+    agentId,
+    input,
+    context = {},
+    onChunk = () => {},
+    onComplete = () => {},
+    onError = () => {}
+  ) {
+    return this._streamRequest(
+      `/organizations/${orgId}/projects/${projectId}/agents/${agentId}/execute/stream`,
+      {
+        method: 'POST',
+        body: {
+          input,
+          context,
+        },
+      },
+      onChunk,
+      onComplete,
+      onError
     );
   }
 

--- a/packages/js-sdk/dist/index.umd.js
+++ b/packages/js-sdk/dist/index.umd.js
@@ -34,6 +34,28 @@
    * 
    * console.log(chatResult.response); // Agent's text response
    * console.log(chatResult.suggestions); // Suggested follow-up questions
+   *
+   * // Streaming chat with session token
+   * await client.chatWithAgentStream(
+   *   session.session_token,
+   *   'Tell me a story',
+   *   null, // conversationId
+   *   null, // userIdentifier
+   *   {}, // dynamicContext
+   *   (chunk) => process.stdout.write(chunk), // onChunk
+   *   (data) => console.log('\n✓ Complete:', data), // onComplete
+   *   (error) => console.error('❌ Error:', error) // onError
+   * );
+   *
+   * // Streaming task execution
+   * await client.executeTaskAgentStream(
+   *   session.session_token,
+   *   'Analyze this data: [1,2,3,4,5]',
+   *   {}, // context
+   *   (chunk) => process.stdout.write(chunk), // onChunk
+   *   (data) => console.log('\n✓ Task Complete:', data), // onComplete
+   *   (error) => console.error('❌ Error:', error) // onError
+   * );
    * ```
    */
 
@@ -145,6 +167,82 @@
       }
 
       throw lastError;
+    }
+
+    /**
+     * Make a streaming request to the API
+     * @private
+     */
+    async _streamRequest(endpoint, options = {}, onChunk, onComplete, onError) {
+      const url = `${this.baseUrl}${endpoint}`;
+      const config = {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.apiKey}`,
+          ...options.headers,
+        },
+        ...options,
+      };
+
+      if (options.body) {
+        config.body = JSON.stringify(options.body);
+      }
+
+      try {
+        const response = await fetch(url, config);
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          const error = new Error(errorData.error || `HTTP ${response.status}`);
+          error.status = response.status;
+          error.code = errorData.code;
+          error.response = errorData;
+          onError(error);
+          return;
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+
+            if (done) {
+              break;
+            }
+
+            const chunk = decoder.decode(value, { stream: true });
+            const lines = chunk.split('\n');
+
+            for (const line of lines) {
+              if (line.startsWith('data: ')) {
+                try {
+                  const data = JSON.parse(line.slice(6));
+                  
+                  if (data.type === 'response_chunk') {
+                    onChunk(data.content);
+                  } else if (data.type === 'complete') {
+                    onComplete(data);
+                  } else if (data.type === 'error') {
+                    const error = new Error(data.error || 'Streaming error');
+                    error.code = data.code;
+                    onError(error);
+                  }
+                } catch (parseError) {
+                  // Ignore malformed JSON lines
+                  console.warn('Failed to parse SSE data:', line);
+                }
+              }
+            }
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      } catch (error) {
+        onError(error);
+      }
     }
 
     // ===== PROMPT EXECUTION =====
@@ -279,6 +377,72 @@
     }
 
     /**
+     * Chat with an agent using streaming (session token)
+     * @param {string} sessionToken - Session token from createAgentSession
+     * @param {string} message - Message to send to the agent
+     * @param {string} conversationId - Optional conversation ID
+     * @param {string} userIdentifier - Optional user identifier
+     * @param {Object} dynamicContext - Optional dynamic context
+     * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+     * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+     * @param {Function} onError - Callback function for errors: (error: Error) => void
+     * @returns {Promise<void>} Promise that resolves when streaming starts
+     */
+    async chatWithAgentStream(
+      sessionToken,
+      message,
+      conversationId = null,
+      userIdentifier = null,
+      dynamicContext = {},
+      onChunk = () => {},
+      onComplete = () => {},
+      onError = () => {}
+    ) {
+      return this._streamRequest('/external/agents/chat/stream', {
+        method: 'POST',
+        headers: {
+          'X-Session-Token': sessionToken,
+        },
+        body: {
+          message,
+          conversationId,
+          userIdentifier,
+          dynamicContext,
+        },
+      }, onChunk, onComplete, onError);
+    }
+
+    /**
+     * Execute a task agent using streaming (session token)
+     * @param {string} sessionToken - Session token from createAgentSession
+     * @param {string} input - Input for the task agent
+     * @param {Object} context - Optional context
+     * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+     * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+     * @param {Function} onError - Callback function for errors: (error: Error) => void
+     * @returns {Promise<void>} Promise that resolves when streaming starts
+     */
+    async executeTaskAgentStream(
+      sessionToken,
+      input,
+      context = {},
+      onChunk = () => {},
+      onComplete = () => {},
+      onError = () => {}
+    ) {
+      return this._streamRequest('/external/agents/execute/stream', {
+        method: 'POST',
+        headers: {
+          'X-Session-Token': sessionToken,
+        },
+        body: {
+          input,
+          context,
+        },
+      }, onChunk, onComplete, onError);
+    }
+
+    /**
      * Chat with an agent using API key (simpler but less secure)
      * @param {string} orgId - Organization ID
      * @param {string} projectId - Project ID
@@ -309,6 +473,86 @@
             dynamicContext,
           },
         }
+      );
+    }
+
+    /**
+     * Chat with an agent using streaming (API key-based)
+     * @param {string} orgId - Organization ID
+     * @param {string} projectId - Project ID 
+     * @param {string} agentId - Agent ID
+     * @param {string} message - Message to send to the agent
+     * @param {string} conversationId - Optional conversation ID
+     * @param {string} userIdentifier - Optional user identifier
+     * @param {Object} dynamicContext - Optional dynamic context
+     * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+     * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+     * @param {Function} onError - Callback function for errors: (error: Error) => void
+     * @returns {Promise<void>} Promise that resolves when streaming starts
+     */
+    async chatWithAgentDirectStream(
+      orgId,
+      projectId,
+      agentId,
+      message,
+      conversationId = null,
+      userIdentifier = null,
+      dynamicContext = {},
+      onChunk = () => {},
+      onComplete = () => {},
+      onError = () => {}
+    ) {
+      return this._streamRequest(
+        `/organizations/${orgId}/projects/${projectId}/agents/${agentId}/chat/stream`,
+        {
+          method: 'POST',
+          body: {
+            message,
+            conversationId,
+            userIdentifier,
+            dynamicContext,
+          },
+        },
+        onChunk,
+        onComplete,
+        onError
+      );
+    }
+
+    /**
+     * Execute a task agent using streaming (API key-based)
+     * @param {string} orgId - Organization ID
+     * @param {string} projectId - Project ID
+     * @param {string} agentId - Agent ID
+     * @param {string} input - Input for the task agent
+     * @param {Object} context - Optional context
+     * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+     * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+     * @param {Function} onError - Callback function for errors: (error: Error) => void
+     * @returns {Promise<void>} Promise that resolves when streaming starts
+     */
+    async executeTaskAgentDirectStream(
+      orgId,
+      projectId,
+      agentId,
+      input,
+      context = {},
+      onChunk = () => {},
+      onComplete = () => {},
+      onError = () => {}
+    ) {
+      return this._streamRequest(
+        `/organizations/${orgId}/projects/${projectId}/agents/${agentId}/execute/stream`,
+        {
+          method: 'POST',
+          body: {
+            input,
+            context,
+          },
+        },
+        onChunk,
+        onComplete,
+        onError
       );
     }
 

--- a/packages/js-sdk/examples/streaming-example.js
+++ b/packages/js-sdk/examples/streaming-example.js
@@ -1,0 +1,113 @@
+/**
+ * Streaming Example for LLM Crafter SDK
+ * 
+ * This example demonstrates how to use the streaming functionality
+ * with both session tokens and API key authentication.
+ */
+
+// Import the SDK (adjust path as needed)
+const { LLMCrafterClient } = require('../src/index.js');
+
+async function streamingExample() {
+  // Initialize the client
+  const client = new LLMCrafterClient('your-api-key', 'https://your-domain.com/api/v1');
+
+  try {
+    console.log('🚀 Starting streaming example...\n');
+
+    // Method 1: Streaming with Session Token
+    console.log('📋 Creating agent session...');
+    const session = await client.createAgentSession('your-agent-id');
+    console.log('✅ Session created:', session.session_id);
+
+    console.log('\n💬 Starting streaming chat with session token...');
+    console.log('Response: ');
+    
+    await client.chatWithAgentStream(
+      session.session_token,
+      'Tell me a short joke about programming',
+      null, // conversationId
+      'example-user', // userIdentifier
+      {}, // dynamicContext
+      (chunk) => {
+        // This function is called for each chunk of the response
+        process.stdout.write(chunk);
+      },
+      (data) => {
+        // This function is called when the response is complete
+        console.log('\n✅ Chat completed!');
+        console.log('Session info:', data.session_info);
+        if (data.suggestions) {
+          console.log('Suggestions:', data.suggestions);
+        }
+      },
+      (error) => {
+        // This function is called if there's an error
+        console.error('\n❌ Chat error:', error.message);
+      }
+    );
+
+    console.log('\n\n🔧 Starting streaming task execution...');
+    console.log('Response: ');
+    
+    await client.executeTaskAgentStream(
+      session.session_token,
+      'Calculate the sum of numbers from 1 to 10',
+      {}, // context
+      (chunk) => {
+        // This function is called for each chunk of the response
+        process.stdout.write(chunk);
+      },
+      (data) => {
+        // This function is called when the task is complete
+        console.log('\n✅ Task completed!');
+        console.log('Execution ID:', data.execution_id);
+        console.log('Session info:', data.session_info);
+      },
+      (error) => {
+        // This function is called if there's an error
+        console.error('\n❌ Task error:', error.message);
+      }
+    );
+
+    // Method 2: Streaming with API Key (Direct)
+    console.log('\n\n🔑 Starting streaming chat with API key...');
+    console.log('Response: ');
+    
+    await client.chatWithAgentDirectStream(
+      'your-org-id',
+      'your-project-id',
+      'your-agent-id',
+      'What is the capital of France?',
+      null, // conversationId
+      'api-user', // userIdentifier
+      {}, // dynamicContext
+      (chunk) => {
+        // This function is called for each chunk of the response
+        process.stdout.write(chunk);
+      },
+      (data) => {
+        // This function is called when the response is complete
+        console.log('\n✅ Direct chat completed!');
+        console.log('Conversation ID:', data.conversation_id);
+      },
+      (error) => {
+        // This function is called if there's an error
+        console.error('\n❌ Direct chat error:', error.message);
+      }
+    );
+
+    console.log('\n\n🏁 Example completed successfully!');
+
+  } catch (error) {
+    console.error('❌ Example failed:', error.message);
+    process.exit(1);
+  }
+}
+
+// Run the example
+if (require.main === module) {
+  streamingExample().catch(console.error);
+}
+
+module.exports = { streamingExample };

--- a/packages/js-sdk/src/index.js
+++ b/packages/js-sdk/src/index.js
@@ -28,6 +28,28 @@
  * 
  * console.log(chatResult.response); // Agent's text response
  * console.log(chatResult.suggestions); // Suggested follow-up questions
+ *
+ * // Streaming chat with session token
+ * await client.chatWithAgentStream(
+ *   session.session_token,
+ *   'Tell me a story',
+ *   null, // conversationId
+ *   null, // userIdentifier
+ *   {}, // dynamicContext
+ *   (chunk) => process.stdout.write(chunk), // onChunk
+ *   (data) => console.log('\n✓ Complete:', data), // onComplete
+ *   (error) => console.error('❌ Error:', error) // onError
+ * );
+ *
+ * // Streaming task execution
+ * await client.executeTaskAgentStream(
+ *   session.session_token,
+ *   'Analyze this data: [1,2,3,4,5]',
+ *   {}, // context
+ *   (chunk) => process.stdout.write(chunk), // onChunk
+ *   (data) => console.log('\n✓ Task Complete:', data), // onComplete
+ *   (error) => console.error('❌ Error:', error) // onError
+ * );
  * ```
  */
 
@@ -139,6 +161,82 @@ class LLMCrafterClient {
     }
 
     throw lastError;
+  }
+
+  /**
+   * Make a streaming request to the API
+   * @private
+   */
+  async _streamRequest(endpoint, options = {}, onChunk, onComplete, onError) {
+    const url = `${this.baseUrl}${endpoint}`;
+    const config = {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`,
+        ...options.headers,
+      },
+      ...options,
+    };
+
+    if (options.body) {
+      config.body = JSON.stringify(options.body);
+    }
+
+    try {
+      const response = await fetch(url, config);
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        const error = new Error(errorData.error || `HTTP ${response.status}`);
+        error.status = response.status;
+        error.code = errorData.code;
+        error.response = errorData;
+        onError(error);
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+
+          if (done) {
+            break;
+          }
+
+          const chunk = decoder.decode(value, { stream: true });
+          const lines = chunk.split('\n');
+
+          for (const line of lines) {
+            if (line.startsWith('data: ')) {
+              try {
+                const data = JSON.parse(line.slice(6));
+                
+                if (data.type === 'response_chunk') {
+                  onChunk(data.content);
+                } else if (data.type === 'complete') {
+                  onComplete(data);
+                } else if (data.type === 'error') {
+                  const error = new Error(data.error || 'Streaming error');
+                  error.code = data.code;
+                  onError(error);
+                }
+              } catch (parseError) {
+                // Ignore malformed JSON lines
+                console.warn('Failed to parse SSE data:', line);
+              }
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    } catch (error) {
+      onError(error);
+    }
   }
 
   // ===== PROMPT EXECUTION =====
@@ -273,6 +371,72 @@ class LLMCrafterClient {
   }
 
   /**
+   * Chat with an agent using streaming (session token)
+   * @param {string} sessionToken - Session token from createAgentSession
+   * @param {string} message - Message to send to the agent
+   * @param {string} conversationId - Optional conversation ID
+   * @param {string} userIdentifier - Optional user identifier
+   * @param {Object} dynamicContext - Optional dynamic context
+   * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+   * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+   * @param {Function} onError - Callback function for errors: (error: Error) => void
+   * @returns {Promise<void>} Promise that resolves when streaming starts
+   */
+  async chatWithAgentStream(
+    sessionToken,
+    message,
+    conversationId = null,
+    userIdentifier = null,
+    dynamicContext = {},
+    onChunk = () => {},
+    onComplete = () => {},
+    onError = () => {}
+  ) {
+    return this._streamRequest('/external/agents/chat/stream', {
+      method: 'POST',
+      headers: {
+        'X-Session-Token': sessionToken,
+      },
+      body: {
+        message,
+        conversationId,
+        userIdentifier,
+        dynamicContext,
+      },
+    }, onChunk, onComplete, onError);
+  }
+
+  /**
+   * Execute a task agent using streaming (session token)
+   * @param {string} sessionToken - Session token from createAgentSession
+   * @param {string} input - Input for the task agent
+   * @param {Object} context - Optional context
+   * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+   * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+   * @param {Function} onError - Callback function for errors: (error: Error) => void
+   * @returns {Promise<void>} Promise that resolves when streaming starts
+   */
+  async executeTaskAgentStream(
+    sessionToken,
+    input,
+    context = {},
+    onChunk = () => {},
+    onComplete = () => {},
+    onError = () => {}
+  ) {
+    return this._streamRequest('/external/agents/execute/stream', {
+      method: 'POST',
+      headers: {
+        'X-Session-Token': sessionToken,
+      },
+      body: {
+        input,
+        context,
+      },
+    }, onChunk, onComplete, onError);
+  }
+
+  /**
    * Chat with an agent using API key (simpler but less secure)
    * @param {string} orgId - Organization ID
    * @param {string} projectId - Project ID
@@ -303,6 +467,86 @@ class LLMCrafterClient {
           dynamicContext,
         },
       }
+    );
+  }
+
+  /**
+   * Chat with an agent using streaming (API key-based)
+   * @param {string} orgId - Organization ID
+   * @param {string} projectId - Project ID 
+   * @param {string} agentId - Agent ID
+   * @param {string} message - Message to send to the agent
+   * @param {string} conversationId - Optional conversation ID
+   * @param {string} userIdentifier - Optional user identifier
+   * @param {Object} dynamicContext - Optional dynamic context
+   * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+   * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+   * @param {Function} onError - Callback function for errors: (error: Error) => void
+   * @returns {Promise<void>} Promise that resolves when streaming starts
+   */
+  async chatWithAgentDirectStream(
+    orgId,
+    projectId,
+    agentId,
+    message,
+    conversationId = null,
+    userIdentifier = null,
+    dynamicContext = {},
+    onChunk = () => {},
+    onComplete = () => {},
+    onError = () => {}
+  ) {
+    return this._streamRequest(
+      `/organizations/${orgId}/projects/${projectId}/agents/${agentId}/chat/stream`,
+      {
+        method: 'POST',
+        body: {
+          message,
+          conversationId,
+          userIdentifier,
+          dynamicContext,
+        },
+      },
+      onChunk,
+      onComplete,
+      onError
+    );
+  }
+
+  /**
+   * Execute a task agent using streaming (API key-based)
+   * @param {string} orgId - Organization ID
+   * @param {string} projectId - Project ID
+   * @param {string} agentId - Agent ID
+   * @param {string} input - Input for the task agent
+   * @param {Object} context - Optional context
+   * @param {Function} onChunk - Callback function for each chunk: (chunk: string) => void
+   * @param {Function} onComplete - Callback function when complete: (data: Object) => void
+   * @param {Function} onError - Callback function for errors: (error: Error) => void
+   * @returns {Promise<void>} Promise that resolves when streaming starts
+   */
+  async executeTaskAgentDirectStream(
+    orgId,
+    projectId,
+    agentId,
+    input,
+    context = {},
+    onChunk = () => {},
+    onComplete = () => {},
+    onError = () => {}
+  ) {
+    return this._streamRequest(
+      `/organizations/${orgId}/projects/${projectId}/agents/${agentId}/execute/stream`,
+      {
+        method: 'POST',
+        body: {
+          input,
+          context,
+        },
+      },
+      onChunk,
+      onComplete,
+      onError
     );
   }
 

--- a/src/models/Agent.js
+++ b/src/models/Agent.js
@@ -132,6 +132,11 @@ const agentSchema = new mongoose.Schema(
         enum: ['basic', 'detailed', 'verbose'],
         default: 'basic',
       },
+      // Streaming config
+      enable_streaming: {
+        type: Boolean,
+        default: false,
+      },
     },
     question_suggestions: {
       enabled: {

--- a/src/routes/agents.js
+++ b/src/routes/agents.js
@@ -56,6 +56,11 @@ const createAgentValidation = [
     .optional()
     .isString()
     .withMessage('Question suggestions custom prompt must be a string'),
+  // Streaming configuration validation
+  body('config.enable_streaming')
+    .optional()
+    .isBoolean()
+    .withMessage('Enable streaming must be a boolean'),
 ];
 
 const updateAgentValidation = [
@@ -105,6 +110,11 @@ const updateAgentValidation = [
     .optional()
     .isString()
     .withMessage('Question suggestions custom prompt must be a string'),
+  // Streaming configuration validation
+  body('config.enable_streaming')
+    .optional()
+    .isBoolean()
+    .withMessage('Enable streaming must be a boolean'),
 ];
 
 const chatbotExecutionValidation = [
@@ -173,12 +183,30 @@ router.post(
 );
 
 router.post(
+  '/:agentId/chat/stream',
+  auth,
+  orgAuth.hasRole('member'),
+  chatbotExecutionValidation,
+  validate,
+  agentController.executeChatbotAgentStream
+);
+
+router.post(
   '/:agentId/execute',
   auth,
   orgAuth.hasRole('member'),
   taskExecutionValidation,
   validate,
   agentController.executeTaskAgent
+);
+
+router.post(
+  '/:agentId/execute/stream',
+  auth,
+  orgAuth.hasRole('member'),
+  taskExecutionValidation,
+  validate,
+  agentController.executeTaskAgentStream
 );
 
 // ===== CONVERSATION MANAGEMENT ROUTES =====

--- a/src/routes/external.js
+++ b/src/routes/external.js
@@ -94,6 +94,26 @@ router.post(
   agentController.executeTaskAgentWithSession
 );
 
+// Chat with an agent using session token (streaming)
+router.post(
+  '/agents/chat/stream',
+  proxyLimiter, // Rate limit: 60 requests per minute
+  sessionAuth,
+  agentChatValidation,
+  validate,
+  agentController.executeChatbotAgentWithSessionStream
+);
+
+// Execute a task agent using session token (streaming)
+router.post(
+  '/agents/execute/stream',
+  proxyLimiter, // Rate limit: 60 requests per minute
+  sessionAuth,
+  agentTaskValidation,
+  validate,
+  agentController.executeTaskAgentWithSessionStream
+);
+
 // Alternative: Chat with agent using API key (for simple use cases)
 // This bypasses the session system but requires agents:chat scope
 router.post(

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -113,6 +113,112 @@ class AgentService {
   }
 
   /**
+   * Execute a chatbot agent with streaming support
+   */
+  async executeChatbotAgentStream(
+    agentId,
+    conversationId,
+    userMessage,
+    userIdentifier,
+    dynamicContext = {},
+    streamCallback = null
+  ) {
+    //populate agent with API key and provider of api key
+    const agent = await Agent.findById(agentId).populate({
+      path: 'api_key',
+      populate: {
+        path: 'provider',
+      },
+    });
+    if (!agent) {
+      throw new Error('Agent not found');
+    }
+
+    if (agent.type !== 'chatbot') {
+      throw new Error('Agent is not a chatbot type');
+    }
+
+    // Get or create conversation
+    let conversation;
+    if (conversationId) {
+      conversation = await Conversation.findById(conversationId);
+      if (!conversation || conversation.agent !== agentId) {
+        throw new Error(
+          'Conversation not found or does not belong to this agent'
+        );
+      }
+    } else {
+      conversation = new Conversation({
+        agent: agentId,
+        user_identifier: userIdentifier,
+        title: this.generateConversationTitle(userMessage),
+      });
+      await conversation.save();
+    }
+
+    // Add user message to conversation
+    await conversation.addMessage({
+      role: 'user',
+      content: userMessage,
+      timestamp: new Date(),
+    });
+
+    // Execute agent reasoning with streaming
+    const response = await this.executeAgentReasoningStream(
+      agent,
+      conversation,
+      dynamicContext,
+      streamCallback
+    );
+
+    // Add assistant response to conversation
+    await conversation.addMessage({
+      role: 'assistant',
+      content: response.content,
+      thinking_process: response.thinking_process,
+      tools_used: response.tools_used,
+      token_usage: response.token_usage,
+      timestamp: new Date(),
+    });
+
+    // Generate question suggestions if enabled
+    let suggestions = null;
+    let suggestionUsage = null;
+
+    if (agent.question_suggestions?.enabled) {
+      const suggestionResult =
+        await suggestionService.generateQuestionSuggestions(
+          agent,
+          conversation.messages
+        );
+
+      if (suggestionResult) {
+        suggestions = suggestionResult.suggestions;
+        suggestionUsage = suggestionResult.usage;
+      }
+    }
+
+    // Check if conversation needs summarization
+    await this.handleConversationSummarization(conversation, agent);
+
+    const result = {
+      conversation_id: conversation._id,
+      response: response.content,
+      thinking_process: response.thinking_process,
+      tools_used: response.tools_used,
+      token_usage: response.token_usage,
+    };
+
+    // Add suggestions to response if available
+    if (suggestions) {
+      result.suggestions = suggestions;
+      result.suggestion_usage = suggestionUsage;
+    }
+
+    return result;
+  }
+
+  /**
    * Execute a task agent with input data
    */
   async executeTaskAgent(
@@ -154,6 +260,70 @@ class AgentService {
         input,
         execution,
         dynamicContext
+      );
+
+      await execution.complete(result.output);
+      execution.usage = result.token_usage;
+      await execution.save();
+
+      return {
+        execution_id: execution._id,
+        output: result.output,
+        thinking_process: execution.thinking_process,
+        tools_used: execution.tools_executed,
+        token_usage: result.token_usage,
+        status: 'completed',
+      };
+    } catch (error) {
+      await execution.fail(error);
+      throw error;
+    }
+  }
+
+  /**
+   * Execute a task agent with streaming support
+   */
+  async executeTaskAgentStream(
+    agentId,
+    input,
+    userIdentifier = null,
+    dynamicContext = {},
+    streamCallback = null
+  ) {
+    const agent = await Agent.findById(agentId).populate({
+      path: 'api_key',
+      populate: {
+        path: 'provider',
+      },
+    });
+    if (!agent) {
+      throw new Error('Agent not found');
+    }
+
+    if (agent.type !== 'task') {
+      throw new Error('Agent is not a task type');
+    }
+
+    // Create execution record
+    const execution = new AgentExecution({
+      agent: agentId,
+      type: 'task',
+      input,
+      metadata: {
+        user_identifier: userIdentifier,
+      },
+    });
+    await execution.save();
+    await execution.start();
+
+    try {
+      // Execute agent reasoning with streaming
+      const result = await this.executeTaskReasoningStream(
+        agent,
+        input,
+        execution,
+        dynamicContext,
+        streamCallback
       );
 
       await execution.complete(result.output);
@@ -307,6 +477,371 @@ class AgentService {
   }
 
   /**
+   * Core agent reasoning engine with streaming support
+   */
+  async executeAgentReasoningStream(agent, conversation, dynamicContext = {}, streamCallback = null) {
+    const decriptedApiKey = agent.api_key.getDecryptedKey();
+    const openai = new OpenAIService(
+      decriptedApiKey,
+      agent.api_key.provider.name
+    );
+
+    const thinkingProcess = [];
+    const toolsUsed = [];
+    const totalTokenUsage = {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+      cost: 0,
+    };
+
+    // Build context for the agent
+    const context = this.buildAgentContext(agent, conversation);
+
+    // Initial reasoning step
+    thinkingProcess.push({
+      step: 'analyze_input',
+      reasoning: 'Analyzing user input and determining response strategy',
+    });
+
+    const maxIterations = agent.config.max_tool_calls || 5;
+    let currentIteration = 0;
+    let finalResponse = '';
+
+    while (currentIteration < maxIterations) {
+      currentIteration++;
+
+      // Build prompt for current iteration
+      const prompt = this.buildReasoningPrompt(
+        agent,
+        context,
+        thinkingProcess,
+        toolsUsed,
+        currentIteration
+      );
+
+      // Get LLM response with streaming
+      const enhancedSystemPrompt = this.buildEnhancedSystemPrompt(
+        agent.system_prompt,
+        dynamicContext
+      );
+
+      let streamBuffer = '';
+      let isStreaming = false;
+      let streamingStarted = false;
+      let responseContentSent = '';
+
+      const onChunk = (chunk) => {
+        streamBuffer += chunk;
+
+        // Check if we've detected a RESPONSE action and should start streaming
+        if (!streamingStarted && this.shouldStartStreaming(streamBuffer)) {
+          isStreaming = true;
+          streamingStarted = true;
+
+          // Extract and stream the response content so far
+          const responseContent = this.extractResponseFromBuffer(streamBuffer);
+          if (responseContent && streamCallback) {
+            streamCallback(responseContent);
+            responseContentSent = responseContent;
+          }
+        } else if (isStreaming && streamCallback) {
+          // Use buffered approach to prevent REASONING from being streamed
+          const safeContent = this.extractSafeStreamingContent(streamBuffer, responseContentSent);
+          if (safeContent && safeContent !== responseContentSent) {
+            const newContent = safeContent.substring(responseContentSent.length);
+            if (newContent) {
+              streamCallback(newContent);
+              responseContentSent = safeContent;
+            }
+          }
+
+          // Check if we should stop streaming (REASONING detected)
+          if (this.shouldStopStreaming(streamBuffer)) {
+            isStreaming = false;
+            return;
+          }
+        }
+      };
+
+      const llmResponse = await openai.generateStreamingCompletion(
+        agent.llm_settings.model,
+        prompt,
+        agent.llm_settings.parameters,
+        enhancedSystemPrompt,
+        onChunk
+      );
+
+      // Update token usage
+      totalTokenUsage.prompt_tokens += llmResponse.usage.prompt_tokens;
+      totalTokenUsage.completion_tokens += llmResponse.usage.completion_tokens;
+      totalTokenUsage.total_tokens += llmResponse.usage.total_tokens;
+      totalTokenUsage.cost += llmResponse.usage.cost;
+
+      // Parse LLM response to determine next action
+      const parsedResponse = this.parseAgentResponse(llmResponse.content);
+
+      if (parsedResponse.action === 'use_tool') {
+        // Execute tool
+        thinkingProcess.push({
+          step: 'tool_execution',
+          reasoning: `Decided to use tool: ${parsedResponse.tool_name}`,
+        });
+
+        const toolResult = await toolService.executeToolWithConfig(
+          parsedResponse.tool_name,
+          parsedResponse.tool_parameters,
+          this.getAgentToolConfig(agent, parsedResponse.tool_name)
+        );
+
+        // Handle tool result properly - check for success/failure
+        const toolResultForAgent = {
+          tool_name: parsedResponse.tool_name,
+          parameters: parsedResponse.tool_parameters,
+          execution_time_ms: toolResult.execution_time_ms,
+        };
+
+        if (toolResult.success) {
+          toolResultForAgent.result = toolResult.result;
+          toolResultForAgent.success = true;
+        } else {
+          toolResultForAgent.error = toolResult.error;
+          toolResultForAgent.success = false;
+          // Add thinking step about tool failure
+          thinkingProcess.push({
+            step: 'tool_failed',
+            reasoning: `Tool ${parsedResponse.tool_name} failed: ${toolResult.error}`,
+          });
+        }
+
+        toolsUsed.push(toolResultForAgent);
+
+        // Continue reasoning with tool result (success or failure)
+        continue;
+      } else if (parsedResponse.action === 'respond') {
+        // Agent decided to respond to user
+        finalResponse = parsedResponse.response;
+        thinkingProcess.push({
+          step: 'final_response',
+          reasoning: 'Determined sufficient information to respond to user',
+        });
+        break;
+      } else {
+        // Continue thinking
+        thinkingProcess.push({
+          step: 'continue_reasoning',
+          reasoning: parsedResponse.reasoning || 'Continuing analysis',
+        });
+      }
+    }
+
+    if (!finalResponse) {
+      finalResponse =
+        "I apologize, but I wasn't able to complete your request within the allowed processing time. Please try rephrasing your request.";
+    }
+
+    return {
+      content: finalResponse,
+      thinking_process: thinkingProcess,
+      tools_used: toolsUsed,
+      token_usage: totalTokenUsage,
+    };
+  }
+
+  /**
+   * Check if we should start streaming based on the buffer content
+   */
+  shouldStartStreaming(buffer) {
+    // Look for ACTION: respond pattern
+    return buffer.includes('ACTION: respond') || buffer.includes('ACTION:respond');
+  }
+
+  /**
+   * Extract response content from buffer when streaming starts
+   */
+  extractResponseFromBuffer(buffer) {
+    const responseIndex = buffer.indexOf('RESPONSE:');
+    if (responseIndex === -1) return '';
+
+    const afterResponse = buffer.substring(responseIndex + 'RESPONSE:'.length);
+
+    // Enhanced pattern matching to catch all field transitions and REASONING variants
+    const nextFieldMatch = afterResponse.match(/\n(ACTION|TOOL|PARAMETERS|REASONING):/i);
+    if (nextFieldMatch) {
+      let content = afterResponse.substring(0, nextFieldMatch.index).trim();
+      
+      // Double-check for any remaining REASONING traces
+      const reasoningCheck = content.toLowerCase().indexOf('reasoning');
+      if (reasoningCheck !== -1) {
+        content = content.substring(0, reasoningCheck).trim();
+      }
+      
+      return content;
+    }
+
+    // If no next field found yet, check for REASONING without newline
+    const reasoningIndex = afterResponse.toLowerCase().indexOf('reasoning');
+    if (reasoningIndex !== -1) {
+      return afterResponse.substring(0, reasoningIndex).trim();
+    }
+
+    // Return what we have, trimmed
+    return afterResponse.trim();
+  }
+
+  /**
+   * Extract new response content from the latest chunk
+   */
+  extractNewResponseContent(buffer, chunk) {
+    // If we're in streaming mode and this chunk contains response content
+    const responseIndex = buffer.indexOf('RESPONSE:');
+    if (responseIndex === -1) return '';
+
+    // Check if this chunk contains "REASONING:" - if so, stop streaming
+    if (chunk.includes('REASONING:') || chunk.includes('\nREASONING:')) {
+      return ''; // Don't stream anything that contains REASONING
+    }
+
+    const beforeChunk = buffer.substring(0, buffer.length - chunk.length);
+    const beforeResponseContent = this.extractResponseFromBuffer(beforeChunk);
+    const currentResponseContent = this.extractResponseFromBuffer(buffer);
+
+    // Return only the new content, but make sure it doesn't contain REASONING
+    if (currentResponseContent.length > beforeResponseContent.length) {
+      const newContent = currentResponseContent.substring(beforeResponseContent.length);
+      
+      // Double-check that the new content doesn't contain REASONING
+      if (newContent.includes('REASONING:')) {
+        return '';
+      }
+      
+      return newContent;
+    }
+
+    return '';
+  }
+
+  /**
+   * Extract safe response content with enhanced REASONING detection
+   */
+  extractSafeResponseContent(buffer, alreadySent = '') {
+    const responseIndex = buffer.indexOf('RESPONSE:');
+    if (responseIndex === -1) return '';
+
+    const afterResponse = buffer.substring(responseIndex + 'RESPONSE:'.length);
+
+    // Look for any field that comes after RESPONSE (ACTION, TOOL, PARAMETERS, REASONING)
+    const nextFieldPatterns = [
+      /\nACTION:/i,
+      /\nTOOL:/i,
+      /\nPARAMETERS:/i,
+      /\nREASONING:/i,
+      /\n\nREASONING:/i,
+      // Also catch variations without newlines
+      /REASONING:/i
+    ];
+
+    let safeEndIndex = afterResponse.length;
+    
+    for (const pattern of nextFieldPatterns) {
+      const match = afterResponse.match(pattern);
+      if (match && match.index !== undefined && match.index < safeEndIndex) {
+        safeEndIndex = match.index;
+      }
+    }
+
+    let safeContent = afterResponse.substring(0, safeEndIndex).trim();
+    
+    // Additional safety: if the content contains any variation of "reasoning", truncate before it
+    const reasoningVariants = ['reasoning:', 'REASONING:', 'Reasoning:', 'reason:', 'REASON:'];
+    for (const variant of reasoningVariants) {
+      const reasoningIndex = safeContent.indexOf(variant);
+      if (reasoningIndex !== -1) {
+        safeContent = safeContent.substring(0, reasoningIndex).trim();
+        break;
+      }
+    }
+
+    return safeContent;
+  }
+
+  /**
+   * Extract safe streaming content with aggressive REASONING prevention
+   */
+  extractSafeStreamingContent(buffer, alreadySent = '') {
+    const responseIndex = buffer.indexOf('RESPONSE:');
+    if (responseIndex === -1) return alreadySent;
+
+    const afterResponse = buffer.substring(responseIndex + 'RESPONSE:'.length);
+    
+    // Look for the start of any next field or REASONING patterns
+    const dangerPatterns = [
+      '\nACTION:',
+      '\nTOOL:',
+      '\nPARAMETERS:',
+      '\nREASONING:',
+      '\n\nREASONING:',
+      'REASONING:',
+      '\nRE', // Catch partial REASONING
+      '\nREA',
+      '\nREAS',
+      '\nREASO',
+      '\nREASON',
+      '\nREASONI',
+      '\nREASONIN',
+      'RE', // Very aggressive - catch even "RE" at end of response to prevent REASONING
+    ];
+
+    let safeContent = afterResponse.trim();
+    let safeEndIndex = safeContent.length;
+
+    // Find the earliest occurrence of any dangerous pattern
+    for (const pattern of dangerPatterns) {
+      const patternIndex = afterResponse.indexOf(pattern);
+      if (patternIndex !== -1 && patternIndex < safeEndIndex) {
+        safeEndIndex = patternIndex;
+      }
+    }
+
+    // Take only the safe portion
+    safeContent = afterResponse.substring(0, safeEndIndex).trim();
+
+    // Additional check: if the content ends with partial REASONING letters, trim them
+    const partialReasoningPatterns = ['R', 'RE', 'REA', 'REAS', 'REASO', 'REASON', 'REASONI', 'REASONIN'];
+    for (const pattern of partialReasoningPatterns) {
+      if (safeContent.endsWith('\n' + pattern) || safeContent.endsWith(pattern)) {
+        // Remove the partial pattern
+        const lastIndex = safeContent.lastIndexOf(pattern);
+        if (lastIndex !== -1) {
+          safeContent = safeContent.substring(0, lastIndex).trim();
+        }
+      }
+    }
+
+    return safeContent;
+  }
+
+  /**
+   * Check if streaming should stop (REASONING detected)
+   */
+  shouldStopStreaming(buffer) {
+    const stopPatterns = [
+      'REASONING:',
+      '\nREASONING:',
+      '\n\nREASONING:',
+      '\nreasoning:',
+    ];
+
+    for (const pattern of stopPatterns) {
+      if (buffer.includes(pattern)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * Task-specific reasoning with iterative tool usage
    */
   async executeTaskReasoning(agent, input, execution, dynamicContext = {}) {
@@ -361,6 +896,210 @@ class AgentService {
         prompt,
         agent.llm_settings.parameters,
         enhancedSystemPrompt
+      );
+
+      // Update token usage
+      totalTokenUsage.prompt_tokens += llmResponse.usage.prompt_tokens;
+      totalTokenUsage.completion_tokens += llmResponse.usage.completion_tokens;
+      totalTokenUsage.total_tokens += llmResponse.usage.total_tokens;
+      totalTokenUsage.cost += llmResponse.usage.cost;
+
+      // Parse LLM response to determine next action
+      const parsedResponse = this.parseAgentResponse(llmResponse.content);
+
+      if (parsedResponse.action === 'use_tool') {
+        // Execute tool
+        thinkingProcess.push({
+          step: 'tool_execution',
+          reasoning: `Decided to use tool: ${parsedResponse.tool_name}`,
+        });
+
+        await execution.addThinkingStep(
+          'tool_execution',
+          `Using tool: ${parsedResponse.tool_name}`
+        );
+
+        const toolResult = await toolService.executeToolWithConfig(
+          parsedResponse.tool_name,
+          parsedResponse.tool_parameters,
+          this.getAgentToolConfig(agent, parsedResponse.tool_name)
+        );
+
+        // Handle tool result properly - check for success/failure
+        const toolResultForAgent = {
+          tool_name: parsedResponse.tool_name,
+          parameters: parsedResponse.tool_parameters,
+          execution_time_ms: toolResult.execution_time_ms,
+        };
+
+        if (toolResult.success) {
+          toolResultForAgent.result = toolResult.result;
+          toolResultForAgent.success = true;
+
+          await execution.addToolExecution(
+            parsedResponse.tool_name,
+            parsedResponse.tool_parameters,
+            toolResult.result,
+            toolResult.execution_time_ms
+          );
+        } else {
+          toolResultForAgent.error = toolResult.error;
+          toolResultForAgent.success = false;
+
+          // Add thinking step about tool failure
+          thinkingProcess.push({
+            step: 'tool_failed',
+            reasoning: `Tool ${parsedResponse.tool_name} failed: ${toolResult.error}`,
+          });
+
+          await execution.addThinkingStep(
+            'tool_failed',
+            `Tool ${parsedResponse.tool_name} failed: ${toolResult.error}`
+          );
+        }
+
+        toolsUsed.push(toolResultForAgent);
+
+        // Continue reasoning with tool result (success or failure)
+        continue;
+      } else if (parsedResponse.action === 'respond') {
+        // Agent decided to provide final output
+        finalOutput = parsedResponse.response;
+        thinkingProcess.push({
+          step: 'task_completed',
+          reasoning: 'Determined sufficient information to complete the task',
+        });
+
+        await execution.addThinkingStep(
+          'task_completed',
+          'Task processing completed with final output'
+        );
+        break;
+      } else {
+        // Continue thinking
+        thinkingProcess.push({
+          step: 'continue_reasoning',
+          reasoning: parsedResponse.reasoning || 'Continuing task analysis',
+        });
+
+        await execution.addThinkingStep(
+          'continue_reasoning',
+          parsedResponse.reasoning || 'Continuing task analysis'
+        );
+      }
+    }
+
+    if (!finalOutput) {
+      finalOutput =
+        "I apologize, but I wasn't able to complete the task within the allowed processing iterations. Please try simplifying the request or providing more specific instructions.";
+
+      await execution.addThinkingStep(
+        'max_iterations_reached',
+        'Maximum iterations reached without completing task'
+      );
+    }
+
+    return {
+      output: finalOutput,
+      token_usage: totalTokenUsage,
+    };
+  }
+
+  /**
+   * Task-specific reasoning with streaming support
+   */
+  async executeTaskReasoningStream(agent, input, execution, dynamicContext = {}, streamCallback = null) {
+    const decryptedApiKey = agent.api_key.getDecryptedKey();
+    const openai = new OpenAIService(
+      decryptedApiKey,
+      agent.api_key.provider.name
+    );
+
+    const thinkingProcess = [];
+    const toolsUsed = [];
+    const totalTokenUsage = {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+      cost: 0,
+    };
+
+    await execution.addThinkingStep(
+      'analyze_task',
+      'Analyzing task input and determining execution strategy'
+    );
+
+    thinkingProcess.push({
+      step: 'analyze_task',
+      reasoning: 'Analyzing task input and determining execution strategy',
+    });
+
+    const maxIterations = agent.config.max_tool_calls || 5;
+    let currentIteration = 0;
+    let finalOutput = '';
+
+    while (currentIteration < maxIterations) {
+      currentIteration++;
+
+      // Build prompt for current iteration
+      const prompt = this.buildTaskReasoningPrompt(
+        agent,
+        input,
+        thinkingProcess,
+        toolsUsed,
+        currentIteration
+      );
+
+      // Get LLM response with streaming
+      const enhancedSystemPrompt = this.buildEnhancedSystemPrompt(
+        agent.system_prompt,
+        dynamicContext
+      );
+
+      let streamBuffer = '';
+      let isStreaming = false;
+      let streamingStarted = false;
+      let responseContentSent = '';
+
+      const onChunk = (chunk) => {
+        streamBuffer += chunk;
+
+        // Check if we've detected a RESPONSE action and should start streaming
+        if (!streamingStarted && this.shouldStartStreaming(streamBuffer)) {
+          isStreaming = true;
+          streamingStarted = true;
+
+          // Extract and stream the response content so far
+          const responseContent = this.extractResponseFromBuffer(streamBuffer);
+          if (responseContent && streamCallback) {
+            streamCallback(responseContent);
+            responseContentSent = responseContent;
+          }
+        } else if (isStreaming && streamCallback) {
+          // Use buffered approach to prevent REASONING from being streamed
+          const safeContent = this.extractSafeStreamingContent(streamBuffer, responseContentSent);
+          if (safeContent && safeContent !== responseContentSent) {
+            const newContent = safeContent.substring(responseContentSent.length);
+            if (newContent) {
+              streamCallback(newContent);
+              responseContentSent = safeContent;
+            }
+          }
+
+          // Check if we should stop streaming (REASONING detected)
+          if (this.shouldStopStreaming(streamBuffer)) {
+            isStreaming = false;
+            return;
+          }
+        }
+      };
+
+      const llmResponse = await openai.generateStreamingCompletion(
+        agent.llm_settings.model,
+        prompt,
+        agent.llm_settings.parameters,
+        enhancedSystemPrompt,
+        onChunk
       );
 
       // Update token usage


### PR DESCRIPTION
- Implemented `executeTaskAgentStream` and `executeChatbotAgentStream` methods in agentController for real-time streaming responses.
- Enhanced `AgentService` with streaming capabilities for both chatbot and task agents, allowing for incremental response delivery.
- Updated `Agent` model to include `enable_streaming` configuration.
- Added validation for streaming configuration in agent creation and update routes.
- Introduced new routes for streaming interactions with agents in both internal and external APIs.
- Enhanced OpenAI service to support streaming completions with chunked responses.